### PR TITLE
add brew-command-not-found-init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ First, tap this repository:
 
 Then source the `handler.sh` script in your `.bashrc`(bash) or `.zshrc`(zsh):
 
-    . $(brew --prefix)/Library/Taps/bfontaine/homebrew-command-not-found/handler.sh
-
+    eval "$(brew command-not-found-init)"
 
 ### Upgrade from 0.1.1
 

--- a/cmd/brew-command-not-found-init.rb
+++ b/cmd/brew-command-not-found-init.rb
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+puts File.read(File.expand_path "#{File.dirname(__FILE__)}/../handler.sh")


### PR DESCRIPTION
This helps to simply the shell source command.